### PR TITLE
Add -verbose flag to print execution stderr/stdout on screen

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,17 +79,15 @@ func main() {
 	start := time.Now()
 
 	out := bytes.NewBuffer(nil)
-	var stdout, stderr io.Writer
-
-	stdout, stderr = out, out
-	if *verbose {
-		stdout = io.MultiWriter(out, os.Stdout)
-		stderr = io.MultiWriter(out, os.Stderr)
-	}
 
 	cmd := exec.Command(exe, args...)
-	cmd.Stdout = stdout
-	cmd.Stderr = stderr
+	cmd.Stdout = out
+	cmd.Stderr = out
+
+	if *verbose {
+		cmd.Stdout = io.MultiWriter(out, os.Stdout)
+		cmd.Stderr = io.MultiWriter(out, os.Stderr)
+	}
 
 	err := cmd.Run()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -45,8 +45,9 @@ func main() {
 	msg := message{}
 
 	var (
-		hook   = flag.String("hook", "", "Slack Incoming Webhook URL")
-		timing = flag.Bool("timing", false, "Include command execution timing")
+		hook    = flag.String("hook", "", "Slack Incoming Webhook URL")
+		timing  = flag.Bool("timing", false, "Include command execution timing")
+		verbose = flag.Bool("verbose", false, "Show command execution on screen")
 	)
 
 	flag.StringVar(&msg.Channel, "channel", "", "Channel where to post the output")
@@ -77,12 +78,26 @@ func main() {
 
 	start := time.Now()
 
-	out, err := exec.Command(exe, args...).CombinedOutput()
+	out := bytes.NewBuffer(nil)
+	var stdout, stderr io.Writer
+
+	stdout, stderr = out, out
+	if *verbose {
+		stdout = io.MultiWriter(out, os.Stdout)
+		stderr = io.MultiWriter(out, os.Stderr)
+	}
+
+	cmd := exec.Command(exe, args...)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	err := cmd.Run()
 	if err != nil {
 		a.Color = "danger"
 		a.addField("Error", err.Error())
+		fmt.Fprintln(os.Stderr, err)
 	}
-	if len(out) > 0 {
+	if out.Len() > 0 {
 		a.Text = fmt.Sprintf("```\n%s```", out)
 	}
 


### PR DESCRIPTION
This flag allows to view the results of execution of the program on the running screen as well as sending the combined output to Slack.

I'm not very happy with the current code yet, but it works.